### PR TITLE
Add support for opening hyperlinks

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -70,6 +70,12 @@ export function App({ vscode }: { vscode: any }) {
         defaultValue={defaultValue}
         value={value}
         onChange={handleChange}
+        onClickLink={(href) => {
+          vscode.postMessage({
+            type: "openLink",
+            text: href
+          })}
+        }
         autoFocus
       />
     </div>

--- a/src/richMarkdownEditor.ts
+++ b/src/richMarkdownEditor.ts
@@ -71,6 +71,9 @@ export class RichMarkdownEditor implements vscode.CustomTextEditorProvider {
       switch (e.type) {
         case "add":
           return this.updateTextDocument(document, e.text)
+        case "openLink":
+          vscode.env.openExternal(vscode.Uri.parse(e.text));
+          return true;
       }
     })
 


### PR DESCRIPTION
This PR should be able to fix the hyperlink issue.

Currently, clicking hyperlink doesn't work because of the restrictions of VS Code. The default behavior of [rich-markdown-editor](https://github.com/outline/rich-markdown-editor) is to open the link in a new tab (`window.open`), but WebViews in VS Code are running in an iframe, which by default, doesn't allow such behavior.

![image](https://user-images.githubusercontent.com/14989893/193644155-c9afd46b-cbce-453e-b939-e1f9dfd92bcc.png)

This PR fixed it by overriding the default behavior `onOpenLink` and using VS Code API to open the link in browser.

![image](https://user-images.githubusercontent.com/14989893/193644731-cad323fc-0e8f-4254-a7a2-06ff3be4c286.png)
