### PR TITLE
work around the cursor bug

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,8 +42,8 @@ export function markdownToOutline(markdownText: string) {
 }
 
 export function isBasicallySame(a = "", b = "") {
-  // Remove slashes and trailing whitespace to compare outline and vanilla markdown strings
-  return a.replace(SLASH_REG, "").trim() === b.replace(SLASH_REG, "").trim()
+  // Remove slashes and trailing whitespace, normalize EOL-characters to compare outline and vanilla markdown strings
+  return a.replace(SLASH_REG, "").replace(/\r\n/g, "\n").trim() === b.replace(SLASH_REG, "").replace(/\r\n/g, "\n").trim()
 }
 
 export function formatText(text = "") {


### PR DESCRIPTION
Avoid unnecessary refreshes of the editor-content, if the file content has not been changed. Ignore different end-of-line characters in the file content and current editor content. 

I could reproduce the mentioned bug in the issues #10, #1 on my Windows machine. Looking at the update-events from VSCode I noticed that the file contents were the same, except for the EOL-characters. I'm not sure this fixes the error for everyone. But for me it made the extension usable again