### PR TITLE
Fix font family configuration retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,22 @@ Perfect for writing docs, authoring blog posts, and editing markdown website con
 
 This extension replaces the default code editor for markdown files with a rich version, allowing you to "edit" in preview mode.
 
-It uses the [rich-markdown-editor](https://github.com/outline/rich-markdown-editor) project generously open sourced by [Outline](https://www.getoutline.com/)
+## Customization
+
+You can customize the editor's appearance through VS Code settings:
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `rich-markdown-editor.fontSize` | Font size for the editor | `16px` |
+| `rich-markdown-editor.fontFamily` | Font family for rendering markdown | System default font stack |
+
+Example settings in `settings.json`:
+
+```json
+"rich-markdown-editor.fontSize": "18px",
+"rich-markdown-editor.fontFamily": "Dank Mono, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+```
+
+## Credits
+
+This extension uses the [rich-markdown-editor](https://github.com/outline/rich-markdown-editor) project generously open sourced by [Outline](https://www.getoutline.com/)

--- a/src/richMarkdownEditor.ts
+++ b/src/richMarkdownEditor.ts
@@ -90,7 +90,7 @@ export class RichMarkdownEditor implements vscode.CustomTextEditorProvider {
 
     const fontFamily = vscode.workspace
       .getConfiguration("rich-markdown-editor")
-      .get("fontSize", DEFAULT_FONT_FAMILY)
+      .get("fontFamily", DEFAULT_FONT_FAMILY)
 
     // Local path to script and css for the webview
     const scriptUri = webview.asWebviewUri(


### PR DESCRIPTION
## Bug Fix: Font Family Configuration

### Issue Description
When using the `rich-markdown-editor.fontFamily` setting, the font family wasn't being applied because the extension was incorrectly reading the font family configuration.

The bug was in `richMarkdownEditor.ts` where the code was calling `.get("fontSize", DEFAULT_FONT_FAMILY)` instead of `.get("fontFamily", DEFAULT_FONT_FAMILY)`.

### Changes Made
1. Fixed the configuration retrieval in `richMarkdownEditor.ts` to correctly use the "fontFamily" property name
2. Updated the README with documentation on how to customize fonts in the editor
3. Added examples to make customization more clear for users

### Testing Done
Verified that the font family setting now correctly applies when set in VS Code settings.